### PR TITLE
Tri numérique des équipes dans le menu

### DIFF
--- a/src/components/pratiques.jsx
+++ b/src/components/pratiques.jsx
@@ -8,6 +8,7 @@ import TableRow from "@mui/material/TableRow";
 import Paper from "@mui/material/Paper";
 import Container from "@mui/material/Container";
 import Typography from "@mui/material/Typography";
+import { sortTeams } from "../shared/teamUtils";
 
 const joursSemaine = [
   "Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"
@@ -105,12 +106,14 @@ function Pratiques() {
   );
 
   // Extraire toutes les équipes uniques
-  const equipes = Array.from(
-    new Map(
-      pratiques
-        .flatMap((p) => p.equipes || [])
-        .map((eq) => [eq.documentId, eq])
-    ).values()
+  const equipes = sortTeams(
+    Array.from(
+      new Map(
+        pratiques
+          .flatMap((p) => p.equipes || [])
+          .map((eq) => [eq.documentId, eq])
+      ).values()
+    )
   );
 
   if (loading) return <div>Chargement...</div>;

--- a/src/shared/teamUtils.js
+++ b/src/shared/teamUtils.js
@@ -1,0 +1,38 @@
+export const teamComparator = (a, b) => {
+  const orderSuffix = ['-1', '-2', 'A', 'B', 'C', '-BB'];
+
+  const normalize = (name) => name ? name.trim().toUpperCase() : '';
+
+  const classify = (team) => {
+    const name = normalize(team.Nom || team);
+    if (name === 'GARDIENS') return { group: 1 };
+    if (name === 'ENTRAINEURS' || name === 'ENTRAÎNEURS') return { group: 2 };
+    const match = name.match(/^M(\d+)(.*)$/);
+    if (match) {
+      const level = parseInt(match[1], 10);
+      const suffix = match[2].replace(/\s+/g, '');
+      const rank = orderSuffix.indexOf(suffix);
+      return {
+        group: 0,
+        level,
+        rank: rank === -1 ? orderSuffix.length : rank,
+        name,
+      };
+    }
+    return { group: 3, name };
+  };
+
+  const infoA = classify(a);
+  const infoB = classify(b);
+
+  if (infoA.group !== infoB.group) return infoA.group - infoB.group;
+  if (infoA.group === 0) {
+    if (infoA.level !== infoB.level) return infoA.level - infoB.level;
+    if (infoA.rank !== infoB.rank) return infoA.rank - infoB.rank;
+  }
+  const nameA = a.Nom || a;
+  const nameB = b.Nom || b;
+  return nameA.localeCompare(nameB);
+};
+
+export const sortTeams = (teams) => teams.sort(teamComparator);


### PR DESCRIPTION
## Summary
- Ajout d'un utilitaire de tri pour ordonner les équipes
- Application de ce tri dans le menu de sélection des pratiques

## Testing
- `CI=true yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a5441d33a083268a1db75422f2c37d